### PR TITLE
move gem sass-rails outside assets group to fix load error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,10 @@ gem 'paperclip'
 gem 'pg', '~> 1.1'
 gem 'puma'
 gem 'rabl'
+gem 'sass-rails'
 
 group :assets do
   gem 'coffee-rails'
-  gem 'sass-rails'
   gem 'uglifier'
 end
 


### PR DESCRIPTION
apparently sprockets 3 depends on sass or something
c.f. https://github.com/rails/sprockets/issues/588#issuecomment-438807554